### PR TITLE
New Box on Homepage: "Transfer Pricing & InnerSource"

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,7 +51,7 @@
 
       {{ partial "home-block-light.html" (dict 
         "title" "Transfer Pricing & InnerSource" 
-        "text" "Our article on how cost contribution agreements enable tax compliance for InnerSource." 
+        "text" "Our comprehensive article on how cost contribution agreements enable tax compliance for InnerSource." 
         "href" "/blog/2022/article-transfer-pricing-innersource-mnetax/")
       }}
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,6 +48,12 @@
         "text" "Immediate support for ongoing transfer pricing audits." 
         "href" "mailto:info@kolabri.io")
       }}
+
+      {{ partial "home-block-light.html" (dict 
+      "title" "Transfer Pricing & InnerSource" 
+      "text" "Our professional article on how cost contribution agreements enable tax compliance for InnerSource." 
+      "href" "/blog/2022/article-transfer-pricing-innersource-mnetax/")
+      }}
     </div>
   </div>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -50,9 +50,9 @@
       }}
 
       {{ partial "home-block-light.html" (dict 
-      "title" "Transfer Pricing & InnerSource" 
-      "text" "Our professional article on how cost contribution agreements enable tax compliance for InnerSource." 
-      "href" "/blog/2022/article-transfer-pricing-innersource-mnetax/")
+        "title" "Transfer Pricing & InnerSource" 
+        "text" "Our article on how cost contribution agreements enable tax compliance for InnerSource." 
+        "href" "/blog/2022/article-transfer-pricing-innersource-mnetax/")
       }}
     </div>
   </div>


### PR DESCRIPTION
To not give up our Google ranking for the term "transfer pricing & InnerSource" (and some permutations thereof), I'd like to add another box linking to our MNE tax article.

Once we have "topics"-sections (InnerSource, DevOps, Scrum, ...), we'll change the link to point there.